### PR TITLE
Bmg remove admin for check

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Each command does only one thing, and there is no GUI interface. To use:
 3. Enter administrator password if prompted
 4. Reboot
 
-:warning: **MUST RUN AS ADMINISTRATOR** :warning:
-
 To check the status of DPST:
 * `get-status.bat`
+
+:warning: **MUST RUN AS ADMINISTRATOR** :warning:
 
 To disable DPST:
 * `disable-dpst.bat`

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ It is notably used on the Microsoft Surface line of products, as well as many ot
 Each command does only one thing, and there is no GUI interface. To use:
 1. Download and unzip. Does not have an installer
 2. Select file
-2. Right-click, Select: "Run as Administrator"
-3. Enter administrator password if prompted
-4. Reboot
+3. If you're running `get-status.bat` you don't have to run as admin, otherwise:
+4. Right-click, Select: "Run as Administrator"
+5. Enter administrator password if prompted
+6. Reboot
 
 To check the status of DPST:
 * `get-status.bat`

--- a/dpst-control.ps1
+++ b/dpst-control.ps1
@@ -127,12 +127,6 @@ If( $Debug ) {
     $DebugPreference = "Continue"   # Enable debug output
 }
 
-# This script must run as admin
-If( !(RunningAsAdmin) ) {
-    Write-Error "Must run as Administrator!"
-    Exit 255
-}
-
 # Search registry for FTC entry
 $ftcPath = LocateFTC -regPath ${regBase}
 If( $ftcPath -eq $false ) {
@@ -184,9 +178,15 @@ Else {
         Exit 1
     }
     Else {
-        Write-Output "DPST is disabled"   
+        Write-Output "DPST is disabled"
         Exit 0
     }
+}
+
+# This script must run as admin if the value is going to be overwritten
+If( !(RunningAsAdmin) ) {
+    Write-Error "Must run as Administrator!"
+    Exit 255
 }
 
 


### PR DESCRIPTION
I updated the main powershell script to no longer require admin rights to check the status of the DPST bit.

Pretty straight forward, just moved where the check is done to after the ifelse statement that currently exists since the check case never actually makes it that far. Additionally, I removed some spare spaces at the end of one of the lines because I saw them and it bothered me.

Seems to me like the only command that really needs Admin is the Set-ItemProperty command at the end of the script. Additionally, and the main reason I did this to begin with, it makes it easier to create a script to automatically disable the bit.

If I'm missing something here let me know.